### PR TITLE
Cancel-Then-Retry-Unit-Testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primeanalytiq/emberflow",
-  "version": "1.3.36",
+  "version": "1.3.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primeanalytiq/emberflow",
-      "version": "1.3.36",
+      "version": "1.3.41",
       "dependencies": {
         "@google-cloud/billing": "^3.4.0",
         "@google-cloud/functions": "^2.5.0",

--- a/src/index-utils.ts
+++ b/src/index-utils.ts
@@ -157,7 +157,7 @@ export async function runBusinessLogics(
   entity: string,
   action: Action,
   distributeFn: (logicResults: LogicResult[], page: number) => Promise<void>,
-) {
+): Promise<"done" | "cancel-then-retry" | "no-matching-logics"> {
   const matchingLogics = logicConfigs.filter((logic) => {
     return (
       (logic.actionTypes === "all" || logic.actionTypes.includes(actionType)) &&
@@ -169,7 +169,7 @@ export async function runBusinessLogics(
   if (matchingLogics.length === 0) {
     console.log("No matching logics found");
     await distributeFn([], 0);
-    return;
+    return "no-matching-logics";
   }
 
   const config = (await db.doc("@server/config").get()).data();
@@ -198,6 +198,9 @@ export async function runBusinessLogics(
         }
 
         logicResults.push({...result, execTime, timeFinished: admin.firestore.Timestamp.now()});
+        if (status === "cancel-then-retry") {
+          return "cancel-then-retry";
+        }
       } catch (e) {
         const end = performance.now();
         const execTime = end - start;
@@ -219,6 +222,7 @@ export async function runBusinessLogics(
       break;
     }
   }
+  return "done";
 }
 
 export function groupDocsByUserAndDstPath(docsByDstPath: Map<string, LogicResultDoc[]>, userId: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,7 +310,7 @@ export async function onFormSubmit(
 
     console.info("Running Business Logics");
     let errorMessage = "";
-    await runBusinessLogics(
+    const runStatus = await runBusinessLogics(
       actionType,
       formModifiedFields,
       entity,
@@ -397,6 +397,12 @@ export async function onFormSubmit(
         await queueRunViewLogics(userDocs);
       }
     );
+
+    if (runStatus === "cancel-then-retry") {
+      await formRef.update({"@status": "cancelled", "@message": "cancel-then-retry received " +
+              "from business logic"});
+      return;
+    }
 
     if (errorMessage) {
       await actionRef.update({status: "finished-with-error", message: errorMessage});

--- a/src/tests/utils/forms.test.ts
+++ b/src/tests/utils/forms.test.ts
@@ -118,6 +118,30 @@ describe("onMessageSubmitFormQueue", () => {
     expect(trackProcessedIdsMock).toHaveBeenCalledWith(SUBMIT_FORM_TOPIC_NAME, event.id);
     expect(result).toEqual("Processed form data");
   });
+
+  it("should throw an error for cancel-then-retry", async () => {
+    isProcessedMock.mockResolvedValueOnce(false);
+    const formData: FormData = {
+      "@docPath": "users/test-uid",
+      "@actionType": "create",
+      "@status": "cancelled",
+      "@message": "cancel-then-retry received from business logic",
+    };
+    const event = {
+      id: "test-event",
+      data: {
+        message: {
+          json: formData,
+        },
+      },
+    } as CloudEvent<MessagePublishedData>;
+
+    try {
+      await forms.onMessageSubmitFormQueue(event);
+    } catch (error) {
+      expect(error).toEqual(new Error("cancel-then-retry"));
+    }
+  });
 });
 
 describe("cleanActionsAndForms", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface InstructionsMessage{
 
 export interface LogicResult{
     name: string;
-    status: "finished" | "error" | "partial-result";
+    status: "finished" | "error" | "partial-result" | "cancel-then-retry";
     nextPage?: AnyObject;
     message?: string;
     execTime?: number;

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -34,7 +34,6 @@ export async function onMessageSubmitFormQueue(event: CloudEvent<MessagePublishe
   console.log("Received form submission:", formData);
 
   formData = await submitForm(formData);
-  // TODO: Test this
   const status = formData["@status"];
   const message = formData["@message"];
   if (status === "cancelled" && message.startsWith("cancel-then-retry")) {


### PR DESCRIPTION
Added unit test for when onMessageSubmitFormQueue throws an error.
Added unit test for when onFormSubmit receives cancel-then-retry from business logics to set form status to cancelled.
Added unit test for when runBusinessLogics finds a logic result status of cancel-then-retry to stop processing other logics and return.