### PR TITLE
use-firestore-update-for-merge-action

### DIFF
--- a/src/index-utils.ts
+++ b/src/index-utils.ts
@@ -61,9 +61,17 @@ export async function distributeDoc(logicResultDoc: LogicResultDoc, batch?: Batc
 
     const updateData: { [key: string]: any } = {...doc, "@id": dstDocRef.id};
     if (batch) {
-      await batch.set(dstDocRef, updateData);
+      if (action === "merge") {
+        await batch.update(dstDocRef, updateData);
+      } else {
+        await batch.set(dstDocRef, updateData);
+      }
     } else {
-      await dstDocRef.set(updateData, {merge: true});
+      if (action === "merge") {
+        await dstDocRef.update(updateData);
+      } else {
+        await dstDocRef.set(updateData);
+      }
     }
     console.log(`Document merged to ${dstPath}`);
   } else if (action === "submit-form") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,17 +191,17 @@ export function initializeEmberFlow(
     timeoutSeconds: 540,
   }, cleanPubSubProcessedIds);
   functionsConfig["cleanMetricComputations"] = onSchedule({
-    schedule: "every 1 hours",
+    schedule: "every 24 hours",
     region: projectConfig.region,
     timeoutSeconds: 540,
   }, cleanMetricComputations);
   functionsConfig["cleanMetricExecutions"] = onSchedule({
-    schedule: "every 1 hours",
+    schedule: "every 24 hours",
     region: projectConfig.region,
     timeoutSeconds: 540,
   }, cleanMetricExecutions);
   functionsConfig["cleanActionsAndForms"] = onSchedule({
-    schedule: "every 1 hours",
+    schedule: "every 24 hours",
     region: projectConfig.region,
     timeoutSeconds: 540,
   }, cleanActionsAndForms);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,9 @@ import {
   ViewLogicConfig,
 } from "./types";
 import {
-  cleanLogicMetricsExecutions,
+  cleanMetricComputations,
+  cleanMetricExecutions,
+  createMetricComputation,
   delayFormSubmissionAndCheckIfCancelled,
   distribute,
   distributeLater,
@@ -20,7 +22,6 @@ import {
   getFormModifiedFields,
   getSecurityFn, groupDocsByTargetDocPath,
   onDeleteFunction,
-  processScheduledEntities,
   runBusinessLogics,
   validateForm,
 } from "./index-utils";
@@ -189,21 +190,26 @@ export function initializeEmberFlow(
     region: projectConfig.region,
     timeoutSeconds: 540,
   }, cleanPubSubProcessedIds);
-  functionsConfig["cleanLogicMetricsExecutions"] = onSchedule({
+  functionsConfig["cleanMetricComputations"] = onSchedule({
     schedule: "every 1 hours",
     region: projectConfig.region,
     timeoutSeconds: 540,
-  }, cleanLogicMetricsExecutions);
+  }, cleanMetricComputations);
+  functionsConfig["cleanMetricExecutions"] = onSchedule({
+    schedule: "every 1 hours",
+    region: projectConfig.region,
+    timeoutSeconds: 540,
+  }, cleanMetricExecutions);
   functionsConfig["cleanActionsAndForms"] = onSchedule({
     schedule: "every 1 hours",
     region: projectConfig.region,
     timeoutSeconds: 540,
   }, cleanActionsAndForms);
-  functionsConfig["minuteFunctions"] = onSchedule({
-    schedule: "every 1 minutes",
+  functionsConfig["createMetricComputation"] = onSchedule({
+    schedule: "every 1 hours",
     region: projectConfig.region,
     timeoutSeconds: 540,
-  }, processScheduledEntities);
+  }, createMetricComputation);
   functionsConfig["reduceInstructions"] = onSchedule({
     schedule: "every 1 minutes",
     region: projectConfig.region,

--- a/src/tests/index-utils.test.ts
+++ b/src/tests/index-utils.test.ts
@@ -68,15 +68,18 @@ describe("distributeDoc", () => {
   let queueRunViewLogicsSpy: jest.SpyInstance;
   let queueInstructionsSpy: jest.SpyInstance;
   let docSetMock: jest.Mock;
+  let docUpdateMock: jest.Mock;
   let docDeleteMock: jest.Mock;
   const batch = BatchUtil.getInstance();
   jest.spyOn(BatchUtil, "getInstance").mockImplementation(() => batch);
 
   beforeEach(() => {
     docSetMock = jest.fn().mockResolvedValue({});
+    docUpdateMock = jest.fn().mockResolvedValue({});
     docDeleteMock = jest.fn().mockResolvedValue({});
     const dbDoc = ({
       set: docSetMock,
+      update: docUpdateMock,
       delete: docDeleteMock,
       id: "test-doc-id",
     } as unknown) as admin.firestore.DocumentReference<admin.firestore.DocumentData>;
@@ -140,8 +143,8 @@ describe("distributeDoc", () => {
     await indexUtils.distributeDoc(logicResultDoc);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
-    expect(docSetMock).toHaveBeenCalledTimes(1);
-    expect(docSetMock).toHaveBeenCalledWith(expectedData, {merge: true});
+    expect(docUpdateMock).toHaveBeenCalledTimes(1);
+    expect(docUpdateMock).toHaveBeenCalledWith(expectedData);
     expect(queueRunViewLogicsSpy).toHaveBeenCalledTimes(1);
     expect(queueRunViewLogicsSpy).toHaveBeenCalledWith(logicResultDoc);
   });
@@ -169,14 +172,14 @@ describe("distributeDoc", () => {
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
     expect(queueInstructionsSpy).toHaveBeenCalledTimes(1);
     expect(queueInstructionsSpy).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id", logicResultDoc.instructions);
-    expect(docSetMock).toHaveBeenCalledTimes(1);
-    expect(docSetMock).toHaveBeenCalledWith(expectedData, {merge: true});
+    expect(docUpdateMock).toHaveBeenCalledTimes(1);
+    expect(docUpdateMock).toHaveBeenCalledWith(expectedData);
     expect(queueRunViewLogicsSpy).toHaveBeenCalledTimes(1);
     expect(queueRunViewLogicsSpy).toHaveBeenCalledWith(logicResultDoc);
   });
 
   it("should merge documents in batch", async () => {
-    const batchSetSpy = jest.spyOn(batch, "set").mockResolvedValue(undefined);
+    const batchSetSpy = jest.spyOn(batch, "update").mockResolvedValue(undefined);
     const logicResultDoc: LogicResultDoc = {
       action: "merge",
       priority: "normal",
@@ -250,7 +253,7 @@ describe("distribute", () => {
   });
 
   it("should merge a document to dstPath and queue instructions", async () => {
-    const batchSetSpy = jest.spyOn(batch, "set").mockResolvedValue(undefined);
+    const batchSetSpy = jest.spyOn(batch, "update").mockResolvedValue(undefined);
 
     const userDocsByDstPath = new Map([[
       "/users/test-user-id/documents/test-doc-id",

--- a/src/tests/utils/distribution.test.ts
+++ b/src/tests/utils/distribution.test.ts
@@ -190,12 +190,12 @@ describe("queueInstructions", () => {
 
 describe("onMessageInstructionsQueue", () => {
   let dbSpy: jest.SpyInstance;
-  let docSetMock: jest.Mock;
+  let docUpdateMock: jest.Mock;
 
   beforeEach(() => {
-    docSetMock = jest.fn().mockResolvedValue({});
+    docUpdateMock = jest.fn().mockResolvedValue({});
     const dbDoc = ({
-      set: docSetMock,
+      update: docUpdateMock,
       id: "test-doc-id",
     } as unknown) as admin.firestore.DocumentReference<admin.firestore.DocumentData>;
     dbSpy = jest.spyOn(admin.firestore(), "doc").mockReturnValue(dbDoc);
@@ -226,7 +226,7 @@ describe("onMessageInstructionsQueue", () => {
 
     expect(console.log).toHaveBeenCalledWith("Invalid instruction arr[Earth] for property planets");
     expect(console.log).toHaveBeenCalledWith("Invalid instruction arr{Asia} for property continents");
-    expect(docSetMock.mock.calls[0][0]).toStrictEqual({});
+    expect(docUpdateMock.mock.calls[0][0]).toStrictEqual({});
   });
 
   it("should log no values found when parenthesis is empty", async () => {
@@ -247,7 +247,7 @@ describe("onMessageInstructionsQueue", () => {
     await distribution.onMessageInstructionsQueue(event);
 
     expect(console.log).toHaveBeenCalledWith("No values found in instruction arr() for property planets");
-    expect(docSetMock.mock.calls[0][0]).toStrictEqual({});
+    expect(docUpdateMock.mock.calls[0][0]).toStrictEqual({});
   });
 
   it("should convert array union instructions correctly", async () => {
@@ -274,7 +274,7 @@ describe("onMessageInstructionsQueue", () => {
     } as CloudEvent<MessagePublishedData>;
     await distribution.onMessageInstructionsQueue(event);
 
-    expect(docSetMock.mock.calls[0][0]).toStrictEqual(expectedData);
+    expect(docUpdateMock.mock.calls[0][0]).toStrictEqual(expectedData);
   });
 
   it("should convert array remove instructions correctly", async () => {
@@ -301,8 +301,8 @@ describe("onMessageInstructionsQueue", () => {
     } as CloudEvent<MessagePublishedData>;
     await distribution.onMessageInstructionsQueue(event);
 
-    expect(docSetMock.mock.calls[0][0]).toStrictEqual({});
-    expect(docSetMock.mock.calls[1][0]).toStrictEqual(expectedData);
+    expect(docUpdateMock.mock.calls[0][0]).toStrictEqual({});
+    expect(docUpdateMock.mock.calls[1][0]).toStrictEqual(expectedData);
   });
 
   it("should convert array union and remove instructions correctly in a single field", async () => {
@@ -328,8 +328,8 @@ describe("onMessageInstructionsQueue", () => {
     } as CloudEvent<MessagePublishedData>;
     await distribution.onMessageInstructionsQueue(event);
 
-    expect(docSetMock.mock.calls[0][0]).toStrictEqual(expectedData);
-    expect(docSetMock.mock.calls[1][0]).toStrictEqual(expectedRemoveData);
+    expect(docUpdateMock.mock.calls[0][0]).toStrictEqual(expectedData);
+    expect(docUpdateMock.mock.calls[1][0]).toStrictEqual(expectedRemoveData);
   });
 
   it("should skip duplicate message", async () => {
@@ -380,11 +380,11 @@ describe("onMessageInstructionsQueue", () => {
 
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
-    expect(docSetMock).toHaveBeenCalledTimes(2);
-    expect(docSetMock).toHaveBeenCalledWith(expectedData, {merge: true});
-    expect(docSetMock).toHaveBeenCalledWith(expectedRemoveData, {merge: true});
-    expect(docSetMock.mock.calls[0][0]).toStrictEqual(expectedData);
-    expect(docSetMock.mock.calls[1][0]).toStrictEqual(expectedRemoveData);
+    expect(docUpdateMock).toHaveBeenCalledTimes(2);
+    expect(docUpdateMock).toHaveBeenCalledWith(expectedData);
+    expect(docUpdateMock).toHaveBeenCalledWith(expectedRemoveData);
+    expect(docUpdateMock.mock.calls[0][0]).toStrictEqual(expectedData);
+    expect(docUpdateMock.mock.calls[1][0]).toStrictEqual(expectedRemoveData);
     expect(trackProcessedIdsMock).toHaveBeenCalledWith(INSTRUCTIONS_TOPIC_NAME, event.id);
     expect(result).toEqual("Processed instructions");
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,12 +105,6 @@ export interface QueryCondition {
 
 export type AnyObject = { [key: string]: any };
 
-export interface ScheduledEntity {
-    colPath: string;
-    data: { [key: string]: any };
-    runAt: Timestamp;
-}
-
 export interface EventContext {
     id: string;
     uid: string;

--- a/src/utils/batch.ts
+++ b/src/utils/batch.ts
@@ -2,6 +2,7 @@ import {DocumentData, DocumentReference} from "firebase-admin/lib/firestore";
 import {db} from "../index";
 import {firestore} from "firebase-admin";
 import WriteBatch = firestore.WriteBatch;
+import UpdateData = firestore.UpdateData;
 
 
 export class BatchUtil {
@@ -45,7 +46,7 @@ export class BatchUtil {
 
   async update<T extends DocumentData>(
     docRef: DocumentReference<T>,
-    document: DocumentData,
+    document: UpdateData<T>,
   ): Promise<void> {
     (await this.getBatch()).update(docRef, document);
     this.writeCount++;

--- a/src/utils/batch.ts
+++ b/src/utils/batch.ts
@@ -43,6 +43,18 @@ export class BatchUtil {
     }
   }
 
+  async update<T extends DocumentData>(
+    docRef: DocumentReference<T>,
+    document: DocumentData,
+  ): Promise<void> {
+    (await this.getBatch()).update(docRef, document);
+    this.writeCount++;
+
+    if (this.writeCount >= this.BATCH_SIZE) {
+      await this.commit();
+    }
+  }
+
   async deleteDoc<T extends DocumentData>(
     docRef: DocumentReference<T>,
   ): Promise<void> {

--- a/src/utils/distribution.ts
+++ b/src/utils/distribution.ts
@@ -165,9 +165,9 @@ export async function onMessageInstructionsQueue(event: CloudEvent<MessagePublis
       }
     }
     const dstDocRef = db.doc(dstPath);
-    await dstDocRef.set(updateData, {merge: true});
+    await dstDocRef.update(updateData);
     if (Object.keys(removeData).length > 0) {
-      await dstDocRef.set(removeData, {merge: true});
+      await dstDocRef.update(removeData);
     }
     await pubsubUtils.trackProcessedIds(INSTRUCTIONS_TOPIC_NAME, event.id);
     return "Processed instructions";


### PR DESCRIPTION
Updated distributeDoc to use update for merge action. Added update function in batchUtils.