### PR TITLE
Use empty object when metadata is undefined

### DIFF
--- a/src/index-utils.ts
+++ b/src/index-utils.ts
@@ -252,7 +252,7 @@ export const runBusinessLogics = async (
   txnGet: TxnGet,
   action: Action,
 ): Promise<RunBusinessLogicStatus> => {
-  const {actionType, modifiedFields, document, eventContext: {entity}, metadata = {}} = action;
+  const {actionType, modifiedFields, document, eventContext: {entity}, metadata} = action;
 
   const matchingLogics = getMatchingLogics(actionType, modifiedFields, document, entity, metadata);
   console.debug("Matching logics:", matchingLogics.map((logic) => logic.name));

--- a/src/index.ts
+++ b/src/index.ts
@@ -391,7 +391,7 @@ export async function onFormSubmit(
         entity,
       };
 
-      const metadata = form["@metadata"];
+      const metadata = form["@metadata"] || {};
       const action: Action = {
         eventContext,
         actionType,

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -537,6 +537,7 @@ describe("onFormSubmit", () => {
         name: "test",
       },
       status: "processed-with-errors",
+      metadata: {},
     };
 
     // Test that the runBusinessLogics function was called with the correct parameters

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,8 @@ export interface Action{
     user: DocumentData;
     status: "new" | "processing" | "processed" | "processed-with-errors";
     timeCreated: Timestamp;
+    metadata: Record<string, any>;
     message?: string
-    metadata?: Record<string, any>;
 }
 
 export type TxnGet = Readonly<Pick<firestore.Transaction, "get">>;


### PR DESCRIPTION
I basically set metadata to an empty object when it is undefined, I noticed that when we try to submit a form without @metadata, it will throw an error saying metadata in action is undefined