### PR TITLE
Do not run submit-form in transactional logic-result

### DIFF
--- a/src/index-utils.ts
+++ b/src/index-utils.ts
@@ -148,13 +148,17 @@ export async function distributeDoc(
       console.log(`Document merged to ${dstPath}`);
     }
   } else if (action === "submit-form") {
-    console.debug("Queuing submit form...");
-    const formData: FormData = {
-      "@docPath": dstPath,
-      "@actionType": "create",
-      ...doc,
-    };
-    await queueSubmitForm(formData);
+    if (txn) {
+      console.error("Submit-form is not supported in transactional logic result");
+    } else {
+      console.debug("Queuing submit form...");
+      const formData: FormData = {
+        "@docPath": dstPath,
+        "@actionType": "create",
+        ...doc,
+      };
+      await queueSubmitForm(formData);
+    }
   }
 }
 


### PR DESCRIPTION
In this pull request, I did a minor revision so that distributeDoc will not allow submit-form logicResultDoc if the logic result is transactional

This PR is based on Master branch