### PR TITLE
Distribute docs per patch logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emberflow",
-  "version": "1.4.31",
+  "version": "1.4.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emberflow",
-      "version": "1.4.31",
+      "version": "1.4.32",
       "dependencies": {
         "@google-cloud/billing": "^3.4.0",
         "@google-cloud/functions": "^2.5.0",

--- a/src/index-utils.ts
+++ b/src/index-utils.ts
@@ -266,7 +266,6 @@ function getMatchingLogics(actionType: ActionType, modifiedFields: DocumentData,
           versionCompare(logic.version, targetVersion) <= 0
     );
   });
-  console.debug("All Logics", logicConfigs.map((logic) => logic.name));
 
   // Let's group by name
   const nameIndex = new Map<string, number>();

--- a/src/logics/patch-logics.ts
+++ b/src/logics/patch-logics.ts
@@ -13,8 +13,6 @@ import {
   _mockable, distributeDoc,
   expandConsolidateAndGroupByDstPath,
 } from "../index-utils";
-import {firestore} from "firebase-admin";
-import Transaction = firestore.Transaction;
 import {queueRunViewLogics} from "./view-logics";
 
 export async function queueRunPatchLogics(appVersion: string, ...dstPaths: string[]) {
@@ -47,24 +45,7 @@ export async function onMessageRunPatchLogicsQueue(event: CloudEvent<MessagePubl
     console.info("Running Patch Logics");
     const start = performance.now();
 
-    let patchLogicResults: LogicResult[] = [];
-    const distributeLogicDocs = await db.runTransaction(async (txn) => {
-      const distributedLogicDocs: LogicResultDoc[] = [];
-      patchLogicResults = await runPatchLogics(appVersion, dstPath, txn);
-
-      const patchLogicResultDocs = patchLogicResults.map((result) => result.documents).flat();
-      const dstPathPatchLogicDocsMap: Map<string, LogicResultDoc[]> = await expandConsolidateAndGroupByDstPath(patchLogicResultDocs);
-
-      dstPathPatchLogicDocsMap.forEach((value) => {
-        value.forEach(async (logicResultDoc) => {
-          await distributeDoc(logicResultDoc, undefined, txn);
-          distributedLogicDocs.push(logicResultDoc);
-        });
-      });
-      return distributedLogicDocs;
-    });
-
-    await queueRunViewLogics(appVersion, ...distributeLogicDocs);
+    const patchLogicResults = await runPatchLogics(appVersion, dstPath);
 
     const end = performance.now();
     const execTime = end - start;
@@ -101,50 +82,70 @@ export function versionCompare(version1: string, version2: string): number {
   return 0; // equal
 }
 
-export const runPatchLogics = async (appVersion: string, dstPath: string, txn: Transaction): Promise<LogicResult[]> => {
+export const runPatchLogics = async (appVersion: string, dstPath: string): Promise<LogicResult[]> => {
   const {entity} = findMatchingDocPathRegex(dstPath);
   if (!entity) {
     console.error("Entity should not be blank");
     return [];
   }
 
-  console.log("running here");
-  const logicResults: LogicResult[] = [];
-  const snapshot = await txn.get(db.doc(dstPath));
-  const data = snapshot.data();
-  console.debug("data", data);
-  if (!data) return logicResults;
+  return await db.runTransaction(async (txn) => {
+    const logicResults: LogicResult[] = [];
+    const snapshot = await txn.get(db.doc(dstPath));
+    const data = snapshot.data();
+    console.debug("data", data);
+    if (!data) return logicResults;
+    const dataVersion = data["@dataVersion"] || "0.0.0";
 
-  const dataVersion = data["@dataVersion"] || "0.0.0";
+    const matchingPatchLogics = _mockable.getPatchLogicConfigs()
+      .filter((patchLogicConfig) => {
+        return entity === patchLogicConfig.entity &&
+          versionCompare(dataVersion, patchLogicConfig.version) < 0 &&
+          versionCompare(patchLogicConfig.version, appVersion) <= 0;
+      });
 
-  let count = 0;
-  const matchingPatchLogics = _mockable.getPatchLogicConfigs()
-    .filter((patchLogicConfig) => {
-      count++;
-      console.debug("count", count);
-      return entity === patchLogicConfig.entity &&
-            versionCompare(dataVersion, patchLogicConfig.version) < 0 &&
-        versionCompare(patchLogicConfig.version, appVersion) <= 0;
-    });
-  // TODO: Handle errors
+    for (const patchLogic of matchingPatchLogics) {
+      console.info(`Running Patch Logic ${patchLogic.name}`);
+      const distributedLogicDocs: LogicResultDoc[] = [];
+      const start = performance.now();
+      const patchLogicResult = await patchLogic.patchLogicFn(dstPath, data);
+      const end = performance.now();
+      const execTime = end - start;
 
-  for (const patchLogic of matchingPatchLogics) {
-    const start = performance.now();
-    const patchLogicResult = await patchLogic.patchLogicFn(dstPath, data);
-    patchLogicResult.documents.push({
-      action: "merge",
-      dstPath,
-      doc: {
-        "@dataVersion": patchLogic.version,
-      },
-    });
-    const end = performance.now();
-    const execTime = end - start;
-    logicResults.push({
-      ...patchLogicResult,
-      execTime,
-      timeFinished: admin.firestore.Timestamp.now(),
-    });
-  }
-  return logicResults;
+      const patchLogicResultDocs = patchLogicResult.documents;
+
+      for (const doc of [...patchLogicResultDocs]) {
+        if (doc.action === "delete") continue;
+
+        // this will be consolidated later
+        patchLogicResultDocs.push({
+          action: "merge",
+          dstPath: doc.dstPath,
+          doc: {
+            "@dataVersion": patchLogic.version,
+          },
+        });
+      }
+
+      const dstPathPatchLogicDocsMap: Map<string, LogicResultDoc[]> =
+        await expandConsolidateAndGroupByDstPath(patchLogicResultDocs);
+
+      dstPathPatchLogicDocsMap.forEach((value) => {
+        value.forEach(async (logicResultDoc) => {
+          await distributeDoc(logicResultDoc, undefined, txn);
+          distributedLogicDocs.push(logicResultDoc);
+        });
+      });
+
+      await queueRunViewLogics(appVersion, ...distributedLogicDocs);
+
+      logicResults.push({
+        ...patchLogicResult,
+        documents: distributedLogicDocs,
+        execTime,
+        timeFinished: admin.firestore.Timestamp.now(),
+      });
+    }
+    return logicResults;
+  });
 };


### PR DESCRIPTION
Updated the patch-logics so that it will distribute docs right away before running the succeeding patches