### PR TITLE
fix: Data-Version-Is-Being-Set-To-Highest-Patch-Version

### DIFF
--- a/src/index-utils.ts
+++ b/src/index-utils.ts
@@ -56,6 +56,7 @@ export const _mockable = {
 
 export async function distributeDoc(
   logicResultDoc: LogicResultDoc,
+  appVersion: string,
   batch?: BatchUtil,
   txn?: Transaction) {
   async function _delete(dstDocRef: DocumentReference) {
@@ -153,6 +154,11 @@ export async function distributeDoc(
               });
             if (matchingPatches && matchingPatches.length > 0) {
               doc["@dataVersion"] = matchingPatches.reduce((max, patch) => {
+                // skip if patch.version > appVersion
+                if (versionCompare(patch.version, appVersion) > 0) {
+                  return max;
+                }
+
                 return versionCompare(patch.version, max) > 0 ? patch.version : max;
               }, "0.0.0");
             }
@@ -181,7 +187,7 @@ export async function distributeDoc(
   }
 }
 
-export async function distributeFnNonTransactional(docsByDstPath: Map<string, LogicResultDoc[]>, skipReturn = false) {
+export async function distributeFnNonTransactional(docsByDstPath: Map<string, LogicResultDoc[]>, appVersion: string, skipReturn = false) {
   const distributedDocs: LogicResultDoc[] = [];
   const batch = BatchUtil.getInstance();
   for (const dstPath of Array.from(docsByDstPath.keys()).sort()) {
@@ -192,7 +198,7 @@ export async function distributeFnNonTransactional(docsByDstPath: Map<string, Lo
       if (!skipReturn) {
         distributedDocs.push(resultDoc);
       }
-      await distributeDoc(resultDoc, batch);
+      await distributeDoc(resultDoc, appVersion, batch);
     }
   }
 
@@ -672,6 +678,7 @@ export async function cleanMetricComputations(_event: ScheduledEvent) {
 export async function distributeFnTransactional(
   txn: Transaction,
   logicResults: LogicResult[],
+  appVersion: string,
 ): Promise<LogicResultDoc[]> {
   const distributedLogicResultDocs: LogicResultDoc[] = [];
 
@@ -688,10 +695,9 @@ export async function distributeFnTransactional(
   for (const [_, logicDocs] of transactionalDstPathLogicDocsMap) {
     for (const logicDoc of logicDocs) {
       distributedLogicResultDocs.push(logicDoc);
-      await distributeDoc(logicDoc, undefined, txn);
+      await distributeDoc(logicDoc, appVersion, undefined, txn);
     }
   }
-
 
   return distributedLogicResultDocs;
 }

--- a/src/index-utils.ts
+++ b/src/index-utils.ts
@@ -155,7 +155,7 @@ export async function distributeDoc(
             if (matchingPatches && matchingPatches.length > 0) {
               doc["@dataVersion"] = matchingPatches.reduce((max, patch) => {
                 // skip if patch.version > appVersion
-                if (versionCompare(patch.version, appVersion) > 0) {
+                if (appVersion !== "no_app_version" && versionCompare(patch.version, appVersion) > 0) {
                   return max;
                 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -530,7 +530,8 @@ export async function onFormSubmit(
       logMemoryUsage(`${formId}: After Saving Logic Logics`);
 
       const distributeTransactionalLogicResultsStart = performance.now();
-      const transactionalLogicResults = await distributeFnTransactional(txn, runBusinessLogicStatus.logicResults);
+      const transactionalLogicResults =
+        await distributeFnTransactional(txn, runBusinessLogicStatus.logicResults, appVersion);
       for (const doc of transactionalLogicResults) {
         if (findMatchingViewLogics(doc, targetVersion)?.size) {
           docsForViewLogics.push(doc);
@@ -596,7 +597,7 @@ export async function onFormSubmit(
 
     await formRef.update({"@status": "finished"});
 
-    await queueRunViewLogics(targetVersion, docsForViewLogics);
+    await queueRunViewLogics(targetVersion, appVersion, docsForViewLogics);
     logMemoryUsage(`${formId}: After Saving Transactional Logic Logics`);
 
     await queueRunPatchLogics(
@@ -677,8 +678,8 @@ async function distributeNonTransactionalLogicResults(
   } = groupDocsByTargetDocPath(highPriorityDstPathLogicDocsMap, docPath);
 
   const distributedHighPriorityDocs = [
-    ...await distributeFnNonTransactional(highPriorityDocsByDocPath),
-    ...await distributeFnNonTransactional(highPriorityOtherDocsByDocPath),
+    ...await distributeFnNonTransactional(highPriorityDocsByDocPath, appVersion),
+    ...await distributeFnNonTransactional(highPriorityOtherDocsByDocPath, appVersion),
   ];
   for (const doc of distributedHighPriorityDocs) {
     if (findMatchingViewLogics(doc, targetVersion)?.size) {
@@ -705,7 +706,8 @@ async function distributeNonTransactionalLogicResults(
     otherDocsByDocPath: normalPriorityOtherDocsByDocPath,
   } = groupDocsByTargetDocPath(normalPriorityDstPathLogicDocsMap, docPath);
 
-  const distributedNormalPriorityDocs = await distributeFnNonTransactional(normalPriorityDocsByDocPath);
+  const distributedNormalPriorityDocs =
+    await distributeFnNonTransactional(normalPriorityDocsByDocPath, appVersion);
   for (const doc of distributedNormalPriorityDocs) {
     if (findMatchingViewLogics(doc, targetVersion)?.size) {
       docsForViewLogics.push(doc);
@@ -801,7 +803,7 @@ export const onUserRegister = async (user: UserRecord) => {
     const customUserRegisterFnLogicResult = await customUserRegisterFn(txnGet, user);
     const logicEnd = performance.now();
     console.debug("Distributing logic results");
-    await distributeFnTransactional(txn, [customUserRegisterFnLogicResult]);
+    await distributeFnTransactional(txn, [customUserRegisterFnLogicResult], "999.9.9");
     console.debug("Finished custom user register function");
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -803,7 +803,7 @@ export const onUserRegister = async (user: UserRecord) => {
     const customUserRegisterFnLogicResult = await customUserRegisterFn(txnGet, user);
     const logicEnd = performance.now();
     console.debug("Distributing logic results");
-    await distributeFnTransactional(txn, [customUserRegisterFnLogicResult], "999.9.9");
+    await distributeFnTransactional(txn, [customUserRegisterFnLogicResult], "no_app_version");
     console.debug("Finished custom user register function");
 
     return {

--- a/src/logics/patch-logics.ts
+++ b/src/logics/patch-logics.ts
@@ -200,11 +200,11 @@ export const runPatchLogics = async (appVersion: string, dstPath: string): Promi
         });
       }
 
-      const distributedLogicDocs = await distributeFnTransactional(txn, logicResults);
+      const distributedLogicDocs = await distributeFnTransactional(txn, logicResults, appVersion);
 
       console.debug("Distributed Logic Docs", distributedLogicDocs);
 
-      await queueRunViewLogics(patchVersion, distributedLogicDocs);
+      await queueRunViewLogics(patchVersion, appVersion, distributedLogicDocs);
 
       console.info(`Finished Patch Logic for version ${patchVersion}`);
       return logicResults.map((result) => ({

--- a/src/logics/view-logics.ts
+++ b/src/logics/view-logics.ts
@@ -78,7 +78,7 @@ export function createViewLogicFn(viewDefinition: ViewDefinition): ViewLogicFn[]
     return `${srcPath}/@views/${viewDocId}`;
   }
 
-  const srcToDstLogicFn: ViewLogicFn = async (logicResultDoc, targetVersion, lastProcessedId) => {
+  const srcToDstLogicFn: ViewLogicFn = async (logicResultDoc, targetVersion, appVersion, lastProcessedId) => {
     const {
       doc: srcDoc,
       instructions: srcInstructions,
@@ -287,7 +287,7 @@ export function createViewLogicFn(viewDefinition: ViewDefinition): ViewLogicFn[]
 
     if (atViewsDocs.length >= limitPerBatch) {
       const newLastProcessedId = atViewsDocs[atViewsDocs.length - 1].id;
-      await exports.queueRunViewLogics(targetVersion, [logicResultDoc], newLastProcessedId);
+      await exports.queueRunViewLogics(targetVersion, appVersion, [logicResultDoc], newLastProcessedId);
     }
 
     await syncAtViewsSrcPropsIfDifferentFromViewDefinition();
@@ -437,7 +437,11 @@ export function createViewLogicFn(viewDefinition: ViewDefinition): ViewLogicFn[]
 }
 
 export async function queueRunViewLogics(
-  targetVersion: string, logicResultDocs: LogicResultDoc[], lastProcessedId?: string) {
+  targetVersion: string,
+  appVersion: string,
+  logicResultDocs: LogicResultDoc[],
+  lastProcessedId?: string,
+) {
   try {
     for (const logicResultDoc of logicResultDocs) {
       if (!findMatchingViewLogics(logicResultDoc, targetVersion)?.size) {
@@ -465,7 +469,7 @@ export async function queueRunViewLogics(
           }
         }
         await VIEW_LOGICS_TOPIC.publishMessage({json: {
-          doc: logicResultDoc, targetVersion, lastProcessedId,
+          doc: logicResultDoc, appVersion, targetVersion, lastProcessedId,
         }});
       }
     }
@@ -479,7 +483,12 @@ export async function queueRunViewLogics(
   }
 }
 
-export async function runViewLogics(logicResultDoc: LogicResultDoc, targetVersion: string, lastProcessedId?: string): Promise<LogicResult[]> {
+export async function runViewLogics(
+  logicResultDoc: LogicResultDoc,
+  targetVersion: string,
+  appVersion: string,
+  lastProcessedId?: string,
+): Promise<LogicResult[]> {
   const matchingLogics = findMatchingViewLogics(logicResultDoc, targetVersion);
   if (!matchingLogics || matchingLogics.size === 0) {
     return [];
@@ -489,7 +498,7 @@ export async function runViewLogics(logicResultDoc: LogicResultDoc, targetVersio
   for (const logic of matchingLogics.values()) {
     const start = performance.now();
     try {
-      const viewLogicResult = await logic.viewLogicFn(logicResultDoc, targetVersion, lastProcessedId);
+      const viewLogicResult = await logic.viewLogicFn(logicResultDoc, targetVersion, appVersion, lastProcessedId);
       const end = performance.now();
       const execTime = end - start;
       logicResults.push({
@@ -521,12 +530,12 @@ export async function onMessageViewLogicsQueue(event: CloudEvent<MessagePublishe
   }
 
   try {
-    const {targetVersion, doc, lastProcessedId} = event.data.message.json;
+    const {appVersion, targetVersion, doc, lastProcessedId} = event.data.message.json;
     const logicResultDoc = reviveDateAndTimestamp(doc) as LogicResultDoc;
 
     logMemoryUsage("Before Running View Logics");
     const start = performance.now();
-    const viewLogicResults: LogicResult[] = await exports.runViewLogics(logicResultDoc, targetVersion, lastProcessedId);
+    const viewLogicResults: LogicResult[] = await exports.runViewLogics(logicResultDoc, targetVersion, appVersion, lastProcessedId);
     const end = performance.now();
     logMemoryUsage("After Running View Logics");
     const metricExecutions = convertLogicResultsToMetricExecutions([...viewLogicResults]);
@@ -549,7 +558,7 @@ export async function onMessageViewLogicsQueue(event: CloudEvent<MessagePublishe
     const dstPathViewLogicDocsMap: Map<string, LogicResultDoc[]> = await expandConsolidateAndGroupByDstPath(viewLogicResultDocs);
     logMemoryUsage("After Expanding and Grouping View Logic Results");
 
-    await distributeFnNonTransactional(dstPathViewLogicDocsMap, true);
+    await distributeFnNonTransactional(dstPathViewLogicDocsMap, appVersion, true);
     logMemoryUsage("After Distributing View Logic Results");
 
     await pubsubUtils.trackProcessedIds(VIEW_LOGICS_TOPIC_NAME, event.id);

--- a/src/tests/index-utils.test.ts
+++ b/src/tests/index-utils.test.ts
@@ -92,6 +92,7 @@ describe("distributeDoc", () => {
   let dbDoc: admin.firestore.DocumentReference<admin.firestore.DocumentData>;
   const batch = BatchUtil.getInstance();
   jest.spyOn(BatchUtil, "getInstance").mockImplementation(() => batch);
+  const appVersion = "1.0.0";
 
   beforeEach(() => {
     dbDoc = ({
@@ -126,7 +127,7 @@ describe("distributeDoc", () => {
       "@dateCreated": expect.any(Timestamp),
     };
 
-    await indexUtils.distributeDoc(logicResultDoc);
+    await indexUtils.distributeDoc(logicResultDoc, appVersion);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
     expect(dbDoc.set).toHaveBeenCalledTimes(1);
@@ -145,7 +146,7 @@ describe("distributeDoc", () => {
       "@id": "test-doc-id",
     };
 
-    await indexUtils.distributeDoc(logicResultDoc);
+    await indexUtils.distributeDoc(logicResultDoc, appVersion);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
 
@@ -171,7 +172,7 @@ describe("distributeDoc", () => {
       "@id": "test-doc-id",
     };
 
-    await indexUtils.distributeDoc(logicResultDoc);
+    await indexUtils.distributeDoc(logicResultDoc, appVersion);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
     expect(queueInstructionsSpy).toHaveBeenCalledTimes(1);
@@ -203,7 +204,7 @@ describe("distributeDoc", () => {
       },
     };
 
-    await indexUtils.distributeDoc(logicResultDoc, undefined, transactionMock);
+    await indexUtils.distributeDoc(logicResultDoc, appVersion, undefined, transactionMock);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
     expect(queueInstructionsSpy).not.toHaveBeenCalled();
@@ -231,7 +232,7 @@ describe("distributeDoc", () => {
       dstPath: "/users/test-user-id/documents/test-doc-id",
     };
 
-    await indexUtils.distributeDoc(logicResultDoc);
+    await indexUtils.distributeDoc(logicResultDoc, appVersion);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
     expect(dbDoc.update).not.toHaveBeenCalled();
@@ -244,7 +245,7 @@ describe("distributeDoc", () => {
       dstPath: "/users/test-user-id/documents/test-doc-id",
     };
 
-    await indexUtils.distributeDoc(logicResultDoc);
+    await indexUtils.distributeDoc(logicResultDoc, appVersion);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
     expect(dbDoc.delete).toHaveBeenCalledTimes(1);
@@ -266,7 +267,7 @@ describe("distributeDoc", () => {
       dstPath: "/users/test-user-id/documents/test-doc-id",
     };
 
-    await indexUtils.distributeDoc(logicResultDoc, batch);
+    await indexUtils.distributeDoc(logicResultDoc, appVersion, batch);
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
     expect(queueSubmitFormSpy).toHaveBeenCalledTimes(1);
@@ -295,7 +296,7 @@ describe("distributeDoc", () => {
         "@id": "test-doc-id",
       };
 
-      await indexUtils.distributeDoc(logicResultDoc, undefined, transactionMock);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion, undefined, transactionMock);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
       expect(queueInstructionsSpy).not.toHaveBeenCalled();
@@ -323,7 +324,7 @@ describe("distributeDoc", () => {
       };
 
       const errorSpy = jest.spyOn(console, "error").mockImplementation();
-      await indexUtils.distributeDoc(logicResultDoc, undefined, transactionMock);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion, undefined, transactionMock);
       expect(errorSpy).toHaveBeenCalledWith("Submit-form is not supported in transactional logic result");
       expect(transactionSetMock).toHaveBeenCalledTimes(0);
     });
@@ -344,7 +345,7 @@ describe("distributeDoc", () => {
         "@dateCreated": expect.any(Timestamp),
       };
 
-      await indexUtils.distributeDoc(logicResultDoc, batch);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion, batch);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
       expect(batchSetSpy).toHaveBeenCalledTimes(1);
@@ -366,7 +367,7 @@ describe("distributeDoc", () => {
         "@id": "test-doc-id",
       };
 
-      await indexUtils.distributeDoc(logicResultDoc, batch);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion, batch);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
       expect(batchSetSpy).toHaveBeenCalledTimes(1);
@@ -383,7 +384,7 @@ describe("distributeDoc", () => {
         dstPath: "/users/test-user-id/documents/test-doc-id",
       };
 
-      await indexUtils.distributeDoc(logicResultDoc, batch);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion, batch);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
       expect(batchDeleteSpy).toHaveBeenCalledTimes(1);
@@ -404,7 +405,7 @@ describe("distributeDoc", () => {
         "createdBy": logicResultDoc.doc,
       };
 
-      await indexUtils.distributeDoc(logicResultDoc);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
 
@@ -426,7 +427,7 @@ describe("distributeDoc", () => {
         },
       };
 
-      await indexUtils.distributeDoc(logicResultDoc);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
 
@@ -445,7 +446,7 @@ describe("distributeDoc", () => {
         "createdBy": admin.firestore.FieldValue.delete(),
       };
 
-      await indexUtils.distributeDoc(logicResultDoc);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
 
@@ -470,7 +471,7 @@ describe("distributeDoc", () => {
         },
       };
 
-      await indexUtils.distributeDoc(logicResultDoc);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
 
@@ -494,7 +495,7 @@ describe("distributeDoc", () => {
         },
       };
 
-      await indexUtils.distributeDoc(logicResultDoc);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
       const dstDocRef = db.doc(logicResultDoc.dstPath);
@@ -514,7 +515,7 @@ describe("distributeDoc", () => {
         },
       };
 
-      await indexUtils.distributeDoc(logicResultDoc);
+      await indexUtils.distributeDoc(logicResultDoc, appVersion);
       expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
       expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
       const dstDocRef = db.doc(logicResultDoc.dstPath);
@@ -533,6 +534,7 @@ describe("distribute", () => {
   let dbDoc: admin.firestore.DocumentReference<admin.firestore.DocumentData>;
   const batch = BatchUtil.getInstance();
   jest.spyOn(BatchUtil, "getInstance").mockImplementation(() => batch);
+  const appVersion = "1.0.0";
 
   beforeEach(() => {
     dbDoc = ({
@@ -575,7 +577,7 @@ describe("distribute", () => {
       } as LogicResultDoc],
     ]]);
     initializeEmberFlow(projectConfig, admin, dbStructure, Entity, securityConfigs, validatorConfigs, [], patchLogicConfigs);
-    await indexUtils.distributeFnNonTransactional(userDocsByDstPath);
+    await indexUtils.distributeFnNonTransactional(userDocsByDstPath, appVersion);
 
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
@@ -604,7 +606,7 @@ describe("distribute", () => {
         dstPath: "/users/test-user-id/documents/test-doc-id",
       } as LogicResultDoc],
     ]]);
-    await indexUtils.distributeFnNonTransactional(userDocsByDstPath);
+    await indexUtils.distributeFnNonTransactional(userDocsByDstPath, appVersion);
 
     expect(admin.firestore().doc).toHaveBeenCalledTimes(1);
     expect(admin.firestore().doc).toHaveBeenCalledWith("/users/test-user-id/documents/test-doc-id");
@@ -1809,6 +1811,7 @@ describe("runViewLogics", () => {
 
   it("should run view logics properly", async () => {
     const targetVersion = "2.9.0";
+    const appVersion = "1.0.0";
     const logicResult1: LogicResultDoc = {
       action: "merge" as LogicResultDocAction,
       priority: "normal",
@@ -1823,15 +1826,15 @@ describe("runViewLogics", () => {
     viewLogicFn1V2Point5.mockResolvedValue({});
     viewLogicFn2.mockResolvedValue({});
 
-    const results1 = await runViewLogics(logicResult1, targetVersion);
-    const results2 = await runViewLogics(logicResult2, targetVersion);
+    const results1 = await runViewLogics(logicResult1, targetVersion, appVersion);
+    const results2 = await runViewLogics(logicResult2, targetVersion, appVersion);
     const results = [...results1, ...results2];
 
     expect(viewLogicFn1V2Point5).toHaveBeenCalledTimes(2);
     expect(viewLogicFn1V2Point5.mock.calls[0][0]).toBe(logicResult1);
     expect(viewLogicFn1V2Point5.mock.calls[1][0]).toBe(logicResult2);
     expect(viewLogicFn2).toHaveBeenCalledTimes(1);
-    expect(viewLogicFn2).toHaveBeenCalledWith(logicResult2, targetVersion, undefined);
+    expect(viewLogicFn2).toHaveBeenCalledWith(logicResult2, targetVersion, appVersion, undefined);
     expect(results).toHaveLength(3);
   });
 });

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -995,7 +995,7 @@ describe("onUserRegister", () => {
     expect(runTransactionSpy).toHaveBeenCalledTimes(1);
     expect(transactionSetMock).toHaveBeenCalledTimes(1);
     expect(customUserRegisterLogicFn).toHaveBeenCalled();
-    expect(distributeFnTransactionalSpy).toHaveBeenNthCalledWith(1, mockTxn, [customUserRegisterLogicResult], "999.9.9");
+    expect(distributeFnTransactionalSpy).toHaveBeenNthCalledWith(1, mockTxn, [customUserRegisterLogicResult], "no_app_version");
     expect(saveMetricExecution).toHaveBeenNthCalledWith(1, [
       {name: "onUserRegister", execTime: expect.any(Number)},
       {name: "customUserRegisterLogic", execTime: expect.any(Number)},

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -849,12 +849,12 @@ describe("onFormSubmit", () => {
 
     expect(expandConsolidateAndGroupByDstPathMock).toHaveBeenNthCalledWith(2, highPriorityDocs);
     expect(indexutils.groupDocsByTargetDocPath).toHaveBeenNthCalledWith(1, highPriorityDstPathLogicDocsMap, docPath);
-    expect(indexutils.distributeFnNonTransactional).toHaveBeenNthCalledWith(1, highPriorityDocsByDocPath);
-    expect(indexutils.distributeFnNonTransactional).toHaveBeenNthCalledWith(2, highPriorityOtherDocsByDocPath);
+    expect(indexutils.distributeFnNonTransactional).toHaveBeenNthCalledWith(1, highPriorityDocsByDocPath, "4.0.0");
+    expect(indexutils.distributeFnNonTransactional).toHaveBeenNthCalledWith(2, highPriorityOtherDocsByDocPath, "4.0.0");
 
     expect(expandConsolidateAndGroupByDstPathMock).toHaveBeenNthCalledWith(3, [...normalPriorityDocs, ...additionalNormalPriorityDocs]);
     expect(indexutils.groupDocsByTargetDocPath).toHaveBeenNthCalledWith(2, normalPriorityDstPathLogicDocsMap, docPath);
-    expect(indexutils.distributeFnNonTransactional).toHaveBeenNthCalledWith(3, normalPriorityDocsByDocPath);
+    expect(indexutils.distributeFnNonTransactional).toHaveBeenNthCalledWith(3, normalPriorityDocsByDocPath, "4.0.0");
     expect(indexutils.distributeLater).toHaveBeenNthCalledWith(1, normalPriorityOtherDocsByDocPath, "4.0.0", "1.0.0");
 
     expect(expandConsolidateAndGroupByDstPathMock).toHaveBeenNthCalledWith(4, lowPriorityDocs);
@@ -877,6 +877,7 @@ describe("onFormSubmit", () => {
     // Should run views update using the target version
     expect(queueRunViewLogicsSpy).toHaveBeenCalledWith(
       "1.0.0",
+      "4.0.0",
       distributedLogicResultDocs,
     );
 
@@ -994,7 +995,7 @@ describe("onUserRegister", () => {
     expect(runTransactionSpy).toHaveBeenCalledTimes(1);
     expect(transactionSetMock).toHaveBeenCalledTimes(1);
     expect(customUserRegisterLogicFn).toHaveBeenCalled();
-    expect(distributeFnTransactionalSpy).toHaveBeenNthCalledWith(1, mockTxn, [customUserRegisterLogicResult]);
+    expect(distributeFnTransactionalSpy).toHaveBeenNthCalledWith(1, mockTxn, [customUserRegisterLogicResult], "999.9.9");
     expect(saveMetricExecution).toHaveBeenNthCalledWith(1, [
       {name: "onUserRegister", execTime: expect.any(Number)},
       {name: "customUserRegisterLogic", execTime: expect.any(Number)},

--- a/src/tests/logics/patch-logics.test.ts
+++ b/src/tests/logics/patch-logics.test.ts
@@ -438,7 +438,7 @@ describe("runPatchLogics", () => {
         transactional: true,
         execTime: expect.any(Number),
       },
-    ]);
+    ], appVersion);
     expect(distributeFnTransactionalSpy).toHaveBeenNthCalledWith(2, txnResult2, [
       {
         ...userLogicFn2p5Result,
@@ -456,7 +456,7 @@ describe("runPatchLogics", () => {
         execTime: expect.any(Number),
         transactional: true,
       },
-    ]);
+    ], appVersion);
     expect(queueRunViewLogicsSpy).toHaveBeenCalledTimes(2);
   });
 

--- a/src/tests/logics/view-logics.test.ts
+++ b/src/tests/logics/view-logics.test.ts
@@ -229,6 +229,7 @@ describe("createViewLogicFn", () => {
   });
 
   const targetVersion = "1.0.0";
+  const appVersion = "1.0.0";
 
   it("should log error document does not have @id", async () => {
     jest.spyOn(console, "error").mockImplementation();
@@ -242,7 +243,7 @@ describe("createViewLogicFn", () => {
       },
       priority: "normal",
     };
-    const result = await logicFn[1](logicResultDoc, targetVersion);
+    const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
     expect(result.documents.length).toEqual(0);
     expect(console.error).toHaveBeenCalledWith("Document does not have an @id attribute");
   });
@@ -260,7 +261,7 @@ describe("createViewLogicFn", () => {
       },
       priority: "normal",
     };
-    const result = await logicFn[1](logicResultDoc, targetVersion);
+    const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
     expect(result.documents.length).toEqual(0);
     expect(console.error).toHaveBeenCalledWith("srcPath should not have a placeholder");
   });
@@ -268,7 +269,7 @@ describe("createViewLogicFn", () => {
   it("should create @views doc", async () => {
     let logicFn = viewLogics.createViewLogicFn(vd1);
 
-    let result = await logicFn[1](createLogicResultDoc, targetVersion);
+    let result = await logicFn[1](createLogicResultDoc, targetVersion, appVersion);
     expect(result.documents.length).toEqual(1);
     expect(result.documents[0]).toHaveProperty("action", "merge");
     expect(result.documents[0]).toHaveProperty("dstPath", "users/1234/@views/users+1234");
@@ -280,7 +281,7 @@ describe("createViewLogicFn", () => {
 
     logicFn = viewLogics.createViewLogicFn(vd2);
 
-    result = await logicFn[1]({...createLogicResultDoc, dstPath: "users/1234/posts/987#followers[1234]"}, targetVersion);
+    result = await logicFn[1]({...createLogicResultDoc, dstPath: "users/1234/posts/987#followers[1234]"}, targetVersion, appVersion);
     expect(result.documents.length).toEqual(2);
     expect(result.documents[0]).toHaveProperty("action", "merge");
     expect(result.documents[0])
@@ -299,7 +300,7 @@ describe("createViewLogicFn", () => {
 
     logicFn = viewLogics.createViewLogicFn(vd3);
 
-    result = await logicFn[1]({...createLogicResultDoc, dstPath: "servers/123#createdBy"}, targetVersion);
+    result = await logicFn[1]({...createLogicResultDoc, dstPath: "servers/123#createdBy"}, targetVersion, appVersion);
     expect(result.documents.length).toEqual(1);
     expect(result.documents[0]).toHaveProperty("action", "merge");
     expect(result.documents[0])
@@ -315,7 +316,7 @@ describe("createViewLogicFn", () => {
   it("should delete @views doc", async () => {
     let logicFn = viewLogics.createViewLogicFn(vd1);
 
-    let result = await logicFn[1](deleteLogicResultDoc, targetVersion);
+    let result = await logicFn[1](deleteLogicResultDoc, targetVersion, appVersion);
     expect(result.documents.length).toEqual(1);
     expect(result.documents[0]).toHaveProperty("action", "delete");
     expect(result.documents[0]).toHaveProperty("dstPath", "users/1234/@views/users+1234");
@@ -323,7 +324,7 @@ describe("createViewLogicFn", () => {
     logicFn = viewLogics.createViewLogicFn(vd2);
 
     result = await logicFn[1]({...deleteLogicResultDoc, dstPath: "users/1234/posts/987#followers[1234]",
-    }, targetVersion);
+    }, targetVersion, appVersion);
     expect(result.documents.length).toEqual(2);
     expect(result.documents[0]).toHaveProperty("action", "delete");
     expect(result.documents[0])
@@ -336,7 +337,7 @@ describe("createViewLogicFn", () => {
 
     logicFn = viewLogics.createViewLogicFn(vd3);
 
-    result = await logicFn[1]({...deleteLogicResultDoc, dstPath: "servers/123#createdBy"}, targetVersion);
+    result = await logicFn[1]({...deleteLogicResultDoc, dstPath: "servers/123#createdBy"}, targetVersion, appVersion);
     expect(result.documents.length).toEqual(1);
     expect(result.documents[0]).toHaveProperty("action", "delete");
     expect(result.documents[0])
@@ -359,7 +360,7 @@ describe("createViewLogicFn", () => {
     const logicFn = viewLogics.createViewLogicFn(vd1);
 
     // Call the logic function with the test action
-    const result = await logicFn[0](mergeLogicResultDoc, targetVersion);
+    const result = await logicFn[0](mergeLogicResultDoc, targetVersion, appVersion);
 
     expect(colGetMock).toHaveBeenCalledTimes(1);
     expect(docUpdateMock).not.toHaveBeenCalled();
@@ -389,7 +390,7 @@ describe("createViewLogicFn", () => {
     const logicFn = viewLogics.createViewLogicFn(vd1);
 
     // Call the logic function with the test action
-    const result = await logicFn[0](newDeleteLogicResultDoc, targetVersion);
+    const result = await logicFn[0](newDeleteLogicResultDoc, targetVersion, appVersion);
 
     expect(colGetMock).toHaveBeenCalledTimes(1);
     expect(docUpdateMock).not.toHaveBeenCalled();
@@ -430,7 +431,7 @@ describe("createViewLogicFn", () => {
     const logicFn = viewLogics.createViewLogicFn(vd1);
 
     // Call the logic function with the test action
-    const result = await logicFn[0](mergeLogicResultDoc, targetVersion);
+    const result = await logicFn[0](mergeLogicResultDoc, targetVersion, appVersion);
 
     expect(colGetMock).toHaveBeenCalledTimes(1);
     expect(docSpy).toHaveBeenCalledWith("users/1234/@views/users+456+friends+1234");
@@ -576,7 +577,7 @@ describe("createViewLogicFn", () => {
     const logicFn = viewLogics.createViewLogicFn(vd1);
 
     // Call the logic function with the test action
-    const result = await logicFn[0](mergeLogicResultDoc, targetVersion);
+    const result = await logicFn[0](mergeLogicResultDoc, targetVersion, appVersion);
 
     expect(result).toBeDefined();
     expect(result.documents).toBeDefined();
@@ -598,7 +599,7 @@ describe("createViewLogicFn", () => {
     const logicFn2 = viewLogics.createViewLogicFn(vd2);
 
     // Call the logic function with the test action
-    const result2 = await logicFn2[0](mergeLogicResultDoc, targetVersion);
+    const result2 = await logicFn2[0](mergeLogicResultDoc, targetVersion, appVersion);
 
     // Add your expectations here, e.g., result.documents should have the correct properties and values
     expect(result2).toBeDefined();
@@ -625,7 +626,7 @@ describe("createViewLogicFn", () => {
     expect(document).toHaveProperty("dstPath", "users/890/posts/654+followers[1234]");
     expect(document.doc).toEqual({"name": "John Doe", "@updatedByViewDefinitionAt": expect.any(Timestamp)});
 
-    const resultDelete = await logicFn[0](deleteLogicResultDoc, targetVersion);
+    const resultDelete = await logicFn[0](deleteLogicResultDoc, targetVersion, appVersion);
 
     expect(resultDelete).toBeDefined();
     expect(resultDelete.documents).toBeDefined();
@@ -643,7 +644,7 @@ describe("createViewLogicFn", () => {
     const logicFn3 = viewLogics.createViewLogicFn(vd3);
 
     // Call the logic function with the test action
-    const result3 = await logicFn3[0](userLogicResultDoc, targetVersion);
+    const result3 = await logicFn3[0](userLogicResultDoc, targetVersion, appVersion);
 
     expect(result3).toBeDefined();
     expect(result3.documents).toBeDefined();
@@ -683,7 +684,7 @@ describe("createViewLogicFn", () => {
       },
       priority: "normal",
     };
-    const result = await logicFn[1](logicResultDoc, targetVersion);
+    const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
 
     expect(result.documents[0].dstPath).toBe("topics/topic21/orders/order123/menus/menuItem789/@views/topics+topic21+prepAreas+prepArea2+menus+prepAreaMenuItem34");
   });
@@ -710,7 +711,7 @@ describe("createViewLogicFn", () => {
         "topicId": "topic22",
       },
     };
-    const result = await logicFn[1](logicResultDoc, targetVersion);
+    const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
 
     expect(result.documents[0].dstPath).toBe("topics/topic22/prepAreas/prepArea2/menus/menuItem789/@views/topics+topic21+prepAreas+prepArea2+menus+prepAreaMenuItem34+orderItem");
   });
@@ -736,7 +737,7 @@ describe("createViewLogicFn", () => {
         "@id": "menuItem789",
       },
     };
-    const result = await logicFn[1](logicResultDoc, targetVersion);
+    const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
     expect(result.status).toBe("error");
     expect(result.message).toBe("srcPath should not have a placeholder");
   });
@@ -871,7 +872,7 @@ describe("createViewLogicFn", () => {
 
     const logicFn = viewLogics.createViewLogicFn(vd1);
 
-    const result = await logicFn[0](mergeLogicResultDoc, targetVersion);
+    const result = await logicFn[0](mergeLogicResultDoc, targetVersion, appVersion);
 
     expect(result).toBeDefined();
     expect(result.documents).toBeDefined();
@@ -923,7 +924,7 @@ describe("createViewLogicFn", () => {
 
     const logicFn = viewLogics.createViewLogicFn(vd1);
 
-    const result = await logicFn[0](mergeLogicResultDoc, targetVersion);
+    const result = await logicFn[0](mergeLogicResultDoc, targetVersion, appVersion);
 
     expect(result).toBeDefined();
     expect(result.documents).toBeDefined();
@@ -983,14 +984,14 @@ describe("createViewLogicFn", () => {
 
     const logicFn = viewLogics.createViewLogicFn(vd1);
 
-    const result = await logicFn[0](mergeLogicResultDoc, targetVersion);
+    const result = await logicFn[0](mergeLogicResultDoc, targetVersion, appVersion);
 
     expect(result).toBeDefined();
     expect(result.documents).toBeDefined();
     expect(result.documents.length).toEqual(50);
 
     expect(queueRunViewLogicsSpy).toHaveBeenCalledTimes(1);
-    expect(queueRunViewLogicsSpy).toHaveBeenNthCalledWith(1, targetVersion, [mergeLogicResultDoc], "50thViewId");
+    expect(queueRunViewLogicsSpy).toHaveBeenNthCalledWith(1, targetVersion, appVersion, [mergeLogicResultDoc], "50thViewId");
   });
 
   it("should be able to process succeeding batches of @views", async () => {
@@ -1075,7 +1076,7 @@ describe("createViewLogicFn", () => {
       it("should return finished logicResult with 2 documents", async () => {
         jest.spyOn(pathsMockable, "doesPathExists").mockResolvedValue(false);
 
-        const result = await logicFn[1](logicResultDoc, targetVersion);
+        const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
         expect(result.name).toBe("menuItemIngredient Dst-to-Src");
         expect(result.status).toBe("finished");
         expect(result.timeFinished).toBe(undefined);
@@ -1084,7 +1085,7 @@ describe("createViewLogicFn", () => {
       it("should create @syncCreateView in global collection", async () => {
         jest.spyOn(pathsMockable, "doesPathExists").mockResolvedValue(false);
 
-        const result = await logicFn[1](logicResultDoc, targetVersion);
+        const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
         expect(result.documents[1].dstPath).toBe("@syncCreateViews/topics+topic21+menus+menu1+ingredients");
         expect(result.documents[1].doc).toEqual({
           "destEntity": "menuItemIngredient",
@@ -1102,7 +1103,7 @@ describe("createViewLogicFn", () => {
         jest.spyOn(pathsMockable, "doesPathExists").mockResolvedValue(false);
         const errorSpy = jest.spyOn(console, "error").mockImplementation();
 
-        const result = await logicFn[1](invalidLogicResultDoc, targetVersion);
+        const result = await logicFn[1](invalidLogicResultDoc, targetVersion, appVersion);
         expect(errorSpy).toHaveBeenCalledWith("invalid syncCreate dstPath, topics/topic21/menus/menu1#ingredients");
         expect(result.documents.length).toEqual(1);
         expect(result.documents[0].dstPath).not.toBe("@syncCreateViews/topics+topic21+menus+menu1+ingredients");
@@ -1112,7 +1113,7 @@ describe("createViewLogicFn", () => {
         const infoSpy = jest.spyOn(console, "info").mockImplementation();
         jest.spyOn(pathsMockable, "doesPathExists").mockResolvedValue(true);
 
-        const result = await logicFn[1](logicResultDoc, targetVersion);
+        const result = await logicFn[1](logicResultDoc, targetVersion, appVersion);
         expect(infoSpy).toHaveBeenCalledWith("@syncCreateViews/topics+topic21+menus+menu1+ingredients already exists — skipping creation.");
         expect(result.documents.length).toEqual(1);
         expect(result.documents[0].dstPath).not.toBe("@syncCreateViews/topics+topic21+menus+menu1+ingredients");
@@ -1173,7 +1174,7 @@ describe("createViewLogicFn", () => {
       pathsMockable.doesPathExists = doesPathExistsMock;
 
       it("should auto create source document if there is a matching path in @syncCreateViews", async () => {
-        const result = await logicFn[0](logicResultDoc, targetVersion);
+        const result = await logicFn[0](logicResultDoc, targetVersion, appVersion);
         expect(result.documents.length).toBe(2);
 
         expect(result.documents[0].dstPath).toBe(`${dstPath1}/ingredient1`);
@@ -1181,7 +1182,7 @@ describe("createViewLogicFn", () => {
       });
 
       it("should manually create @view document for each newly created views", async () => {
-        const result = await logicFn[0](logicResultDoc, targetVersion);
+        const result = await logicFn[0](logicResultDoc, targetVersion, appVersion);
 
         const atViewsCollectionPath = `${srcCollection}/ingredient1/@views`;
         expect(result.documents[1].dstPath).toBe(
@@ -1203,7 +1204,7 @@ describe("createViewLogicFn", () => {
           version: "1.0.0",
         });
 
-        const result = await logicFnPropView[0](logicResultDoc, targetVersion);
+        const result = await logicFnPropView[0](logicResultDoc, targetVersion, appVersion);
 
         expect(result.documents.length).toBe(3);
 
@@ -1233,6 +1234,7 @@ describe("queueRunViewLogics", () => {
     ]));
   });
   const targetVersion = "1.0.0";
+  const appVersion = "1.0.0";
 
   it("should queue docs to run view logics", async () => {
     const doc1: LogicResultDoc = {
@@ -1241,10 +1243,10 @@ describe("queueRunViewLogics", () => {
       doc: {name: "test-doc-name-merge"},
       dstPath: "users/test-user-id/documents/doc1",
     };
-    await viewLogics.queueRunViewLogics(targetVersion, [doc1]);
+    await viewLogics.queueRunViewLogics(targetVersion, appVersion, [doc1]);
 
     expect(findMatchingViewLogicsSpy).toHaveBeenCalled();
-    expect(publishMessageSpy).toHaveBeenCalledWith({json: {"doc": doc1, "targetVersion": targetVersion}});
+    expect(publishMessageSpy).toHaveBeenCalledWith({json: {"doc": doc1, targetVersion, appVersion}});
   });
 });
 
@@ -1318,12 +1320,15 @@ describe("onMessageViewLogicsQueue", () => {
     doc: {name: "test-doc-name-updated"},
     dstPath: `users/${userId}`,
   };
+  const targetVersion = "1.0.0";
+  const appVersion = "1.0.0";
   const event = {
     data: {
       message: {
         json: {
           doc: doc1,
-          targetVersion: "1.0.0",
+          targetVersion,
+          appVersion,
         },
       },
     },
@@ -1354,7 +1359,7 @@ describe("onMessageViewLogicsQueue", () => {
     };
     const result = await viewLogics.onMessageViewLogicsQueue(event);
 
-    expect(runViewLogicsSpy).toHaveBeenCalledWith(doc1, "1.0.0", undefined);
+    expect(runViewLogicsSpy).toHaveBeenCalledWith(doc1, targetVersion, appVersion, undefined);
     const expectedMetricExecutions = convertLogicResultsToMetricExecutions([...viewLogicsResult, distributeFnLogicResult]);
     expect(createMetricExecutionSpy).toHaveBeenCalledWith(expectedMetricExecutions);
     expect(expandConsolidateAndGroupByDstPathSpy).toHaveBeenCalled();
@@ -1362,7 +1367,7 @@ describe("onMessageViewLogicsQueue", () => {
     // Since the array is cleared in the function, we can't check its content directly if it's the same reference
     // But we know it was called with the flattened documents
     expect(calledWith).toBeDefined();
-    expect(distributeSpy).toHaveBeenCalledWith(expandConsolidateResult, true);
+    expect(distributeSpy).toHaveBeenCalledWith(expandConsolidateResult, appVersion, true);
     expect(trackProcessedIdsMock).toHaveBeenCalledWith(VIEW_LOGICS_TOPIC_NAME, event.id);
     expect(result).toEqual("Processed view logics");
   });

--- a/src/tests/utils/distribution.test.ts
+++ b/src/tests/utils/distribution.test.ts
@@ -146,8 +146,8 @@ describe("onMessageForDistributionQueue", () => {
     } as CloudEvent<MessagePublishedData>;
     const result = await distribution.onMessageForDistributionQueue(event);
 
-    expect(distributeDocSpy).toHaveBeenCalledWith(doc1);
-    expect(queueRunViewLogicsSpy).toHaveBeenCalledWith( targetVersion, [doc1]);
+    expect(distributeDocSpy).toHaveBeenCalledWith(doc1, appVersion);
+    expect(queueRunViewLogicsSpy).toHaveBeenCalledWith(targetVersion, appVersion, [doc1]);
     expect(queueRunPatchLogicsSpy).toHaveBeenCalledWith(appVersion, doc1.dstPath);
     expect(trackProcessedIdsMock).toHaveBeenCalledWith(FOR_DISTRIBUTION_TOPIC_NAME, event.id);
     expect(result).toEqual("Processed for distribution later");

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,7 +139,7 @@ export interface LogicConfig{
     obsoleteStartingFromVersion?: string;
 }
 
-export type ViewLogicFn = (logicResultDoc: LogicResultDoc, targetVersion: string, lastProcessedId?: string)
+export type ViewLogicFn = (logicResultDoc: LogicResultDoc, targetVersion: string, appVersion: string, lastProcessedId?: string)
     => Promise<LogicResult>;
 export interface ViewLogicConfig{
     name: string;

--- a/src/utils/distribution.ts
+++ b/src/utils/distribution.ts
@@ -51,9 +51,9 @@ export async function onMessageForDistributionQueue(event: CloudEvent<MessagePub
 
     const {priority = "normal"} = logicResultDoc;
     if (priority === "high") {
-      await distributeDoc(logicResultDoc);
+      await distributeDoc(logicResultDoc, appVersion);
       if (findMatchingViewLogics(logicResultDoc, targetVersion)?.size) {
-        await queueRunViewLogics(targetVersion, [logicResultDoc]);
+        await queueRunViewLogics(targetVersion, appVersion, [logicResultDoc]);
       }
       const {basePath} = getDestPropAndDestPropId(logicResultDoc.dstPath);
       const {entity} = findMatchingDocPathRegex(basePath);


### PR DESCRIPTION
Passed appVersion to distributeDoc, distributeFnTransactional, distributeFnNonTransactional, queueRunViewLogics, runViewLogics, and viewLogicFn.
Updated dataVersion to not exceed appVersion.